### PR TITLE
Ignore svgs in sprites directory in fa-web zip

### DIFF
--- a/src/fontawesome/import.clj
+++ b/src/fontawesome/import.clj
@@ -58,7 +58,7 @@
 (defn export-icons [zip-in target]
   (consume-zip
    (fn [entry]
-     (when (re-find #"\.svg$" (:path entry))
+     (when (re-find #"^(?!fontawesome-.+[/\//]sprites).+\.svg$" (:path entry))
        (export-icon (:path entry) (get-zip-entry-content entry) target)))
    zip-in))
 


### PR DESCRIPTION
Extends the svg finding regex to ignore the sprites directory. Closes #1